### PR TITLE
feat: restore portal and fragment functionality

### DIFF
--- a/src/MiniReact.ts
+++ b/src/MiniReact.ts
@@ -15,8 +15,11 @@ import {
 	type EffectCallback,
 	type EffectHook,
 	type ElementType,
+	FRAGMENT,
 	type FunctionalComponent,
 	type MiniReactContext,
+	PORTAL,
+	type PortalElement,
 	type StateHook,
 	type StateOrEffectHook,
 	TEXT_ELEMENT,
@@ -147,6 +150,11 @@ export function render(
 	} else {
 		rootInstances.set(containerNode, newInstance);
 	}
+
+	// Flush any scheduled effects after render
+	if (effectQueue.length > 0) {
+		queueMicrotask(flushEffects);
+	}
 }
 
 /**
@@ -205,7 +213,17 @@ export function useState<T>(initialState: T | (() => T)): UseStateHook<T> {
 			if (container) {
 				// Use the original root element for re-render instead of stale element from instance
 				const rootElement = rootElements.get(container) || null;
-				render(rootElement, container);
+				if (rootElement) {
+					render(rootElement, container);
+				} else {
+					console.warn(
+						"No root element found for container, skipping re-render",
+					);
+				}
+			} else {
+				console.warn(
+					"No root container found for hook instance, skipping re-render",
+				);
 			}
 		}
 	};
@@ -376,11 +394,49 @@ export function useContext<T>(context: MiniReactContext<T>): T {
  * @returns The root container element or null
  */
 function findRootContainer(instance: VDOMInstance): HTMLElement | null {
+	// Strategy 1: Walk up the parent chain and validate rootContainer references
+	let current: VDOMInstance | undefined = instance;
+	let depth = 0;
+	while (current) {
+		if (current.rootContainer) {
+			// Verify this rootContainer is actually a real root by checking our rootInstances map
+			for (const [container, rootInstance] of rootInstances) {
+				if (container === current.rootContainer && rootInstance) {
+					return container;
+				}
+			}
+		}
+		current = current.parent;
+		depth++;
+		if (depth > 10) {
+			console.warn(
+				"Parent chain depth exceeded 10, breaking to avoid infinite loop",
+			);
+			break;
+		}
+	}
+
+	// Strategy 2: Search through all root instances to find the one containing this instance
 	for (const [container, rootInstance] of rootInstances) {
 		if (rootInstance && isInstanceInTree(instance, rootInstance)) {
 			return container;
 		}
 	}
+
+	// Strategy 3: If not found in main trees, check if this instance is part of a portal tree
+	current = instance;
+	while (current) {
+		if (current.element.type === PORTAL) {
+			// Found a portal parent - now find which root tree contains this portal
+			for (const [container, rootInstance] of rootInstances) {
+				if (rootInstance && isInstanceInTree(current, rootInstance)) {
+					return container;
+				}
+			}
+		}
+		current = current.parent;
+	}
+
 	return null;
 }
 
@@ -432,6 +488,58 @@ function flushEffects(): void {
 	} finally {
 		isFlushingEffects = false;
 	}
+}
+
+/**
+ * Fragment component - renders children without creating a wrapper DOM node
+ */
+export const Fragment: typeof FRAGMENT = FRAGMENT;
+
+/**
+ * Creates a portal element that renders its children into a different DOM container
+ * @param children The children to render in the portal
+ * @param targetContainer The DOM container to render into
+ * @returns A portal element
+ */
+export function createPortal(
+	children:
+		| AnyMiniReactElement
+		| AnyMiniReactElement[]
+		| string
+		| number
+		| null
+		| undefined,
+	targetContainer: HTMLElement,
+): PortalElement {
+	if (!targetContainer) {
+		throw new Error("Portal target cannot be null or undefined");
+	}
+
+	// Normalize children similar to createElement
+	const childrenArray = Array.isArray(children) ? children : [children];
+	const normalizedChildren = childrenArray
+		.flat()
+		.filter((child) => child !== null && child !== undefined)
+		.map((child) => {
+			if (typeof child === "string" || typeof child === "number") {
+				return {
+					type: TEXT_ELEMENT,
+					props: {
+						nodeValue: child,
+						children: [],
+					},
+				};
+			}
+			return child;
+		});
+
+	return {
+		type: PORTAL,
+		props: {
+			children: normalizedChildren,
+			targetContainer,
+		},
+	};
 }
 
 /* ******* */

--- a/src/domRenderer.ts
+++ b/src/domRenderer.ts
@@ -21,7 +21,7 @@ export function createDomNode(element: AnyMiniReactElement): Node {
 	const domNode = document.createElement(type as string);
 	// biome-ignore lint/complexity/noForEach: forEach is appropriate here as we need to iterate over object entries with side effects (setting DOM attributes), not transforming to a new array
 	Object.entries(props).forEach(([key, value]) => {
-		if (key === "children") return;
+		if (key === "children" || key === "key") return;
 
 		if (key === "className") {
 			domNode.setAttribute("class", String(value));

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,10 @@
 
 import type { SyntheticEvent } from "./eventSystem";
 
-export type AnyMiniReactElement = MiniReactElement | InternalTextElement;
+export type AnyMiniReactElement =
+	| MiniReactElement
+	| InternalTextElement
+	| PortalElement;
 
 export type FunctionalComponent<P = Record<string, unknown>> = (
 	props: P & { children?: AnyMiniReactElement[] },
@@ -13,7 +16,9 @@ export type FunctionalComponent<P = Record<string, unknown>> = (
 export type ElementType =
 	| string
 	| FunctionalComponent<Record<string, unknown>>
-	| ((...args: never[]) => AnyMiniReactElement | null);
+	| ((...args: never[]) => AnyMiniReactElement | null)
+	| typeof FRAGMENT
+	| typeof PORTAL;
 
 // Event handler types for common events
 export interface EventHandlers {
@@ -72,6 +77,8 @@ export interface InternalTextElement {
 }
 
 export const TEXT_ELEMENT = "TEXT_ELEMENT";
+export const FRAGMENT = Symbol("react.fragment");
+export const PORTAL = Symbol("react.portal");
 
 // ********** //
 // Hook Types //
@@ -132,6 +139,7 @@ export interface VDOMInstance {
 	hooks?: StateOrEffectHook<unknown>[];
 	hookCursor?: number;
 	contextValues?: Map<symbol, unknown>; // For context providers
+	rootContainer?: HTMLElement; // Track root container for root-level instances
 }
 
 // ***************** //
@@ -146,3 +154,11 @@ export interface MiniReactContext<T = unknown> {
 }
 
 export type UseContextHook = <T>(context: MiniReactContext<T>) => T;
+
+export interface PortalElement {
+	type: typeof PORTAL;
+	props: {
+		children: AnyMiniReactElement[];
+		targetContainer: HTMLElement;
+	};
+}

--- a/tests/MiniReact.fragments.test.ts
+++ b/tests/MiniReact.fragments.test.ts
@@ -1,0 +1,305 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Fragment, createElement, render, useState } from "../src/MiniReact";
+
+describe("MiniReact Fragment Tests", () => {
+	let container: HTMLElement;
+
+	beforeEach(() => {
+		container = document.createElement("div");
+		document.body.appendChild(container);
+	});
+
+	describe("Basic Fragment Rendering", () => {
+		test("should render fragment with multiple children", () => {
+			const element = createElement(
+				Fragment,
+				null,
+				createElement("span", null, "First"),
+				createElement("span", null, "Second"),
+			);
+
+			render(element, container);
+
+			expect(container.innerHTML).toBe("<span>First</span><span>Second</span>");
+		});
+
+		test("should render fragment with text children", () => {
+			const element = createElement(Fragment, null, "Hello", " ", "World");
+
+			render(element, container);
+
+			expect(container.innerHTML).toBe("Hello World");
+		});
+
+		test("should render empty fragment", () => {
+			const element = createElement(Fragment, null);
+
+			render(element, container);
+
+			expect(container.innerHTML).toBe("");
+		});
+
+		test("should render fragment with mixed children types", () => {
+			const element = createElement(
+				Fragment,
+				null,
+				"Text",
+				createElement("span", null, "Element"),
+				42,
+			);
+
+			render(element, container);
+
+			expect(container.innerHTML).toBe("Text<span>Element</span>42");
+		});
+	});
+
+	describe("Nested Fragments", () => {
+		test("should render nested fragments", () => {
+			const element = createElement(
+				Fragment,
+				null,
+				createElement("div", null, "Before"),
+				createElement(
+					Fragment,
+					null,
+					createElement("span", null, "Nested1"),
+					createElement("span", null, "Nested2"),
+				),
+				createElement("div", null, "After"),
+			);
+
+			render(element, container);
+
+			expect(container.innerHTML).toBe(
+				"<div>Before</div><span>Nested1</span><span>Nested2</span><div>After</div>",
+			);
+		});
+
+		test("should render deeply nested fragments", () => {
+			const element = createElement(
+				Fragment,
+				null,
+				createElement(
+					Fragment,
+					null,
+					createElement(Fragment, null, createElement("span", null, "Deep")),
+				),
+			);
+
+			render(element, container);
+
+			expect(container.innerHTML).toBe("<span>Deep</span>");
+		});
+	});
+
+	describe("Fragment Updates", () => {
+		test("should update fragment children", () => {
+			function TestComponent({ items }: { items: string[] }) {
+				return createElement(
+					Fragment,
+					null,
+					...items.map((item) => createElement("div", { key: item }, item)),
+				);
+			}
+
+			// Initial render
+			render(createElement(TestComponent, { items: ["A", "B"] }), container);
+			expect(container.innerHTML).toBe("<div>A</div><div>B</div>");
+
+			// Update
+			render(
+				createElement(TestComponent, { items: ["A", "B", "C"] }),
+				container,
+			);
+			expect(container.innerHTML).toBe("<div>A</div><div>B</div><div>C</div>");
+		});
+
+		test("should handle fragment to element replacement", () => {
+			// Render fragment first
+			render(
+				createElement(
+					Fragment,
+					null,
+					createElement("span", null, "A"),
+					createElement("span", null, "B"),
+				),
+				container,
+			);
+			expect(container.innerHTML).toBe("<span>A</span><span>B</span>");
+
+			// Replace with single element
+			render(createElement("div", null, "Single"), container);
+			expect(container.innerHTML).toBe("<div>Single</div>");
+		});
+
+		test("should handle element to fragment replacement", () => {
+			// Render single element first
+			render(createElement("div", null, "Single"), container);
+			expect(container.innerHTML).toBe("<div>Single</div>");
+
+			// Replace with fragment
+			render(
+				createElement(
+					Fragment,
+					null,
+					createElement("span", null, "A"),
+					createElement("span", null, "B"),
+				),
+				container,
+			);
+			expect(container.innerHTML).toBe("<span>A</span><span>B</span>");
+		});
+	});
+
+	describe("Fragment with State", () => {
+		test("should work with useState in parent component", () => {
+			function TestComponent() {
+				const [count, setCount] = useState(0);
+
+				return createElement(
+					"div",
+					null,
+					createElement(
+						"button",
+						{
+							onClick: () => setCount(count + 1),
+						},
+						"Increment",
+					),
+					createElement(
+						Fragment,
+						null,
+						createElement("span", null, "Count: "),
+						createElement("span", null, count.toString()),
+					),
+				);
+			}
+
+			render(createElement(TestComponent, null), container);
+
+			const button = container.querySelector("button");
+			const spans = container.querySelectorAll("span");
+
+			expect(spans[0].textContent).toBe("Count: ");
+			expect(spans[1].textContent).toBe("0");
+
+			// Simulate click
+			button?.click();
+
+			expect(spans[1].textContent).toBe("1");
+		});
+	});
+
+	describe("Fragment with Keys", () => {
+		test("should handle keyed children in fragments", () => {
+			function TestComponent({ reverse }: { reverse: boolean }) {
+				const items = reverse ? ["B", "A"] : ["A", "B"];
+				return createElement(
+					Fragment,
+					null,
+					...items.map((item) => createElement("div", { key: item }, item)),
+				);
+			}
+
+			// Initial render
+			render(createElement(TestComponent, { reverse: false }), container);
+			expect(container.innerHTML).toBe("<div>A</div><div>B</div>");
+
+			// Reverse order
+			render(createElement(TestComponent, { reverse: true }), container);
+			expect(container.innerHTML).toBe("<div>B</div><div>A</div>");
+		});
+	});
+
+	describe("Fragment Edge Cases", () => {
+		test("should handle fragment with null/undefined children", () => {
+			const element = createElement(
+				Fragment,
+				null,
+				createElement("span", null, "Valid"),
+				null,
+				undefined,
+				createElement("span", null, "Also Valid"),
+			);
+
+			render(element, container);
+
+			expect(container.innerHTML).toBe(
+				"<span>Valid</span><span>Also Valid</span>",
+			);
+		});
+
+		test("should handle fragment with conditional children", () => {
+			function TestComponent({ showSecond }: { showSecond: boolean }) {
+				return createElement(
+					Fragment,
+					null,
+					createElement("div", null, "First"),
+					showSecond ? createElement("div", null, "Second") : null,
+				);
+			}
+
+			// Show both
+			render(createElement(TestComponent, { showSecond: true }), container);
+			expect(container.innerHTML).toBe("<div>First</div><div>Second</div>");
+
+			// Hide second
+			render(createElement(TestComponent, { showSecond: false }), container);
+			expect(container.innerHTML).toBe("<div>First</div>");
+		});
+
+		test("should handle removing all fragment children", () => {
+			function TestComponent({ hasChildren }: { hasChildren: boolean }) {
+				return createElement(
+					"div",
+					null,
+					createElement("div", null, "Before"),
+					createElement(
+						Fragment,
+						null,
+						...(hasChildren ? [createElement("span", null, "Child")] : []),
+					),
+					createElement("div", null, "After"),
+				);
+			}
+
+			// With children
+			render(createElement(TestComponent, { hasChildren: true }), container);
+			expect(container.innerHTML).toBe(
+				"<div><div>Before</div><span>Child</span><div>After</div></div>",
+			);
+
+			// Without children
+			render(createElement(TestComponent, { hasChildren: false }), container);
+			expect(container.innerHTML).toBe(
+				"<div><div>Before</div><div>After</div></div>",
+			);
+		});
+	});
+
+	describe("Fragment Performance", () => {
+		test("should efficiently update large fragment lists", () => {
+			function TestComponent({ count }: { count: number }) {
+				const items = Array.from({ length: count }, (_, i) => i);
+				return createElement(
+					Fragment,
+					null,
+					...items.map((i) => createElement("div", { key: i }, `Item ${i}`)),
+				);
+			}
+
+			// Initial render with 100 items
+			render(createElement(TestComponent, { count: 100 }), container);
+			expect(container.children).toHaveLength(100);
+
+			// Update to 150 items
+			render(createElement(TestComponent, { count: 150 }), container);
+			expect(container.children).toHaveLength(150);
+
+			// Update to 50 items
+			render(createElement(TestComponent, { count: 50 }), container);
+			expect(container.children).toHaveLength(50);
+		});
+	});
+});

--- a/tests/MiniReact.portals.test.ts
+++ b/tests/MiniReact.portals.test.ts
@@ -1,0 +1,535 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	createContext,
+	createElement,
+	createPortal,
+	render,
+	useContext,
+	useEffect,
+	useState,
+} from "../src/MiniReact";
+
+describe("MiniReact Portal Tests", () => {
+	let container: HTMLElement;
+	let portalTarget: HTMLElement;
+
+	beforeEach(() => {
+		container = document.createElement("div");
+		container.id = "main-container";
+		document.body.appendChild(container);
+
+		portalTarget = document.createElement("div");
+		portalTarget.id = "portal-target";
+		document.body.appendChild(portalTarget);
+	});
+
+	afterEach(() => {
+		document.body.removeChild(container);
+		document.body.removeChild(portalTarget);
+	});
+
+	describe("Basic Portal Functionality", () => {
+		test("should render portal content to target container", () => {
+			const portalContent = createElement(
+				"div",
+				{ id: "portal-content" },
+				"Portal Content",
+			);
+			const portal = createPortal(portalContent, portalTarget);
+
+			const app = createElement(
+				"div",
+				null,
+				createElement("div", null, "Main Content"),
+				portal,
+			);
+
+			render(app, container);
+
+			// Main content should be in main container
+			expect(container.innerHTML).toBe("<div><div>Main Content</div></div>");
+
+			// Portal content should be in portal target
+			expect(portalTarget.innerHTML).toBe(
+				'<div id="portal-content">Portal Content</div>',
+			);
+		});
+
+		test("should render multiple elements through portal", () => {
+			const portal = createPortal(
+				[
+					createElement("span", null, "First"),
+					createElement("span", null, "Second"),
+				],
+				portalTarget,
+			);
+
+			render(portal, container);
+
+			expect(portalTarget.innerHTML).toBe(
+				"<span>First</span><span>Second</span>",
+			);
+			expect(container.innerHTML).toBe("");
+		});
+
+		test("should render text content through portal", () => {
+			const portal = createPortal("Plain text content", portalTarget);
+
+			render(portal, container);
+
+			expect(portalTarget.textContent).toBe("Plain text content");
+		});
+
+		test("should render nested components through portal", () => {
+			function NestedComponent() {
+				return createElement(
+					"div",
+					{ className: "nested" },
+					createElement("span", null, "Nested Content"),
+				);
+			}
+
+			const portal = createPortal(
+				createElement(NestedComponent, null),
+				portalTarget,
+			);
+
+			render(portal, container);
+
+			expect(portalTarget.innerHTML).toBe(
+				'<div class="nested"><span>Nested Content</span></div>',
+			);
+		});
+	});
+
+	describe("Portal Updates and State Management", () => {
+		test("should update portal content when state changes", () => {
+			const PortalComponent = () => {
+				const [count, setCount] = useState(0);
+
+				return createElement(
+					"div",
+					null,
+					createElement(
+						"button",
+						{
+							onClick: () => setCount(count + 1),
+						},
+						"Increment",
+					),
+					createPortal(
+						createElement("div", { id: "counter" }, `Count: ${count}`),
+						portalTarget,
+					),
+				);
+			};
+
+			render(createElement(PortalComponent, null), container);
+
+			expect(portalTarget.innerHTML).toBe('<div id="counter">Count: 0</div>');
+
+			const button = container.querySelector("button");
+			button?.click();
+
+			expect(portalTarget.innerHTML).toBe('<div id="counter">Count: 1</div>');
+		});
+
+		test("should handle conditional portal rendering", () => {
+			const ConditionalPortal = ({
+				showPortal,
+			}: {
+				showPortal: boolean;
+			}) => {
+				return createElement(
+					"div",
+					null,
+					createElement("div", null, "Main Content"),
+					showPortal
+						? createPortal(
+								createElement("div", null, "Portal Content"),
+								portalTarget,
+							)
+						: null,
+				);
+			};
+
+			// Initially show portal
+			render(createElement(ConditionalPortal, { showPortal: true }), container);
+			expect(portalTarget.innerHTML).toBe("<div>Portal Content</div>");
+
+			// Hide portal
+			render(
+				createElement(ConditionalPortal, { showPortal: false }),
+				container,
+			);
+			expect(portalTarget.innerHTML).toBe("");
+
+			// Show portal again
+			render(createElement(ConditionalPortal, { showPortal: true }), container);
+			expect(portalTarget.innerHTML).toBe("<div>Portal Content</div>");
+		});
+
+		test("should handle portal target changes", () => {
+			const alternateTarget = document.createElement("div");
+			document.body.appendChild(alternateTarget);
+
+			const DynamicPortal = ({
+				useAlternate,
+			}: {
+				useAlternate: boolean;
+			}) => {
+				const target = useAlternate ? alternateTarget : portalTarget;
+				return createPortal(
+					createElement("div", null, "Dynamic Content"),
+					target,
+				);
+			};
+
+			// Initially render to portalTarget
+			render(createElement(DynamicPortal, { useAlternate: false }), container);
+			expect(portalTarget.innerHTML).toBe("<div>Dynamic Content</div>");
+			expect(alternateTarget.innerHTML).toBe("");
+
+			// Switch to alternateTarget
+			render(createElement(DynamicPortal, { useAlternate: true }), container);
+			expect(portalTarget.innerHTML).toBe("");
+			expect(alternateTarget.innerHTML).toBe("<div>Dynamic Content</div>");
+
+			document.body.removeChild(alternateTarget);
+		});
+	});
+
+	describe("Multiple Portals", () => {
+		test("should handle multiple portals to same target", () => {
+			const target2 = document.createElement("div");
+			document.body.appendChild(target2);
+
+			const app = createElement(
+				"div",
+				null,
+				createPortal(createElement("div", null, "Portal 1"), portalTarget),
+				createPortal(createElement("div", null, "Portal 2"), portalTarget),
+				createPortal(createElement("div", null, "Portal 3"), target2),
+			);
+
+			render(app, container);
+
+			expect(portalTarget.innerHTML).toBe(
+				"<div>Portal 1</div><div>Portal 2</div>",
+			);
+			expect(target2.innerHTML).toBe("<div>Portal 3</div>");
+
+			document.body.removeChild(target2);
+		});
+
+		test("should handle multiple portals to different targets", () => {
+			const target2 = document.createElement("div");
+			const target3 = document.createElement("div");
+			document.body.appendChild(target2);
+			document.body.appendChild(target3);
+
+			const app = createElement(
+				"div",
+				null,
+				createPortal(createElement("span", null, "A"), portalTarget),
+				createPortal(createElement("span", null, "B"), target2),
+				createPortal(createElement("span", null, "C"), target3),
+			);
+
+			render(app, container);
+
+			expect(portalTarget.innerHTML).toBe("<span>A</span>");
+			expect(target2.innerHTML).toBe("<span>B</span>");
+			expect(target3.innerHTML).toBe("<span>C</span>");
+
+			document.body.removeChild(target2);
+			document.body.removeChild(target3);
+		});
+	});
+
+	describe("Nested Portals", () => {
+		test("should handle portals within portals", () => {
+			const innerTarget = document.createElement("div");
+			document.body.appendChild(innerTarget);
+
+			const innerPortal = createPortal(
+				createElement("div", { id: "inner" }, "Inner Portal"),
+				innerTarget,
+			);
+
+			const outerPortal = createPortal(
+				createElement(
+					"div",
+					{ id: "outer" },
+					createElement("span", null, "Outer Content"),
+					innerPortal,
+				),
+				portalTarget,
+			);
+
+			render(outerPortal, container);
+
+			expect(portalTarget.innerHTML).toBe(
+				'<div id="outer"><span>Outer Content</span></div>',
+			);
+			expect(innerTarget.innerHTML).toBe('<div id="inner">Inner Portal</div>');
+
+			document.body.removeChild(innerTarget);
+		});
+	});
+
+	describe("Event Handling", () => {
+		test("should bubble events through React tree, not DOM tree", () => {
+			const events: string[] = [];
+
+			const ParentComponent = () => {
+				return createElement(
+					"div",
+					{
+						onClick: () => events.push("parent"),
+					},
+					createElement("div", null, "Main Content"),
+					createPortal(
+						createElement(
+							"button",
+							{
+								onClick: () => events.push("portal-button"),
+							},
+							"Portal Button",
+						),
+						portalTarget,
+					),
+				);
+			};
+
+			render(createElement(ParentComponent, null), container);
+
+			const button = portalTarget.querySelector("button");
+			button?.click();
+
+			// Event should bubble through React tree: button -> parent
+			expect(events).toEqual(["portal-button", "parent"]);
+		});
+
+		test("should handle event prevention in portals", () => {
+			const events: string[] = [];
+
+			const App = () => {
+				return createElement(
+					"div",
+					{
+						onClick: () => events.push("parent"),
+					},
+					createPortal(
+						createElement(
+							"button",
+							{
+								onClick: (e: Event) => {
+									events.push("portal-button");
+									e.stopPropagation();
+								},
+							},
+							"Portal Button",
+						),
+						portalTarget,
+					),
+				);
+			};
+
+			render(createElement(App, null), container);
+
+			const button = portalTarget.querySelector("button");
+			button?.click();
+
+			// Event should be stopped, parent should not receive it
+			expect(events).toEqual(["portal-button"]);
+		});
+	});
+
+	describe("Context Propagation", () => {
+		test("should propagate context through portals", () => {
+			const TestContext = createContext("default-value");
+
+			const ContextConsumer = () => {
+				const value = useContext(TestContext);
+				return createElement("div", null, value);
+			};
+
+			const app = createElement(
+				TestContext.Provider,
+				{ value: "test-value" },
+				createElement("div", null, "Main Content"),
+				createPortal(createElement(ContextConsumer, null), portalTarget),
+			);
+
+			render(app, container);
+
+			// Context should work through portal
+			expect(portalTarget.innerHTML).toBe("<div>test-value</div>");
+		});
+	});
+
+	describe("Lifecycle and Effects", () => {
+		test("should call effects in portal components", async () => {
+			const effects: string[] = [];
+
+			const PortalComponent = () => {
+				useEffect(() => {
+					effects.push("mount");
+					return () => effects.push("unmount");
+				}, []);
+
+				return createElement("div", null, "Portal Effect Component");
+			};
+
+			// Mount
+			render(
+				createPortal(createElement(PortalComponent, null), portalTarget),
+				container,
+			);
+
+			// Wait for effects to flush
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(effects).toEqual(["mount"]);
+
+			// Unmount
+			render(createElement("div", null, "Empty"), container);
+
+			// Wait for effects to flush
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(effects).toEqual(["mount", "unmount"]);
+		});
+
+		test("should clean up portal content on unmount", () => {
+			const PortalApp = ({ showPortal }: { showPortal: boolean }) => {
+				return createElement(
+					"div",
+					null,
+					showPortal
+						? createPortal(
+								createElement("div", null, "Portal Content"),
+								portalTarget,
+							)
+						: null,
+				);
+			};
+
+			// Mount with portal
+			render(createElement(PortalApp, { showPortal: true }), container);
+			expect(portalTarget.innerHTML).toBe("<div>Portal Content</div>");
+
+			// Unmount portal
+			render(createElement(PortalApp, { showPortal: false }), container);
+			expect(portalTarget.innerHTML).toBe("");
+		});
+	});
+
+	describe("Edge Cases", () => {
+		test("should handle null portal target gracefully", () => {
+			expect(() => {
+				const portal = createPortal(
+					createElement("div", null, "Content"),
+					null as unknown as HTMLElement,
+				);
+				render(portal, container);
+			}).toThrow("Portal target cannot be null or undefined");
+		});
+
+		test("should handle undefined portal target gracefully", () => {
+			expect(() => {
+				const portal = createPortal(
+					createElement("div", null, "Content"),
+					undefined as unknown as HTMLElement,
+				);
+				render(portal, container);
+			}).toThrow("Portal target cannot be null or undefined");
+		});
+
+		test("should handle portal target that is not in DOM", () => {
+			const detachedTarget = document.createElement("div");
+
+			const portal = createPortal(
+				createElement("div", null, "Content"),
+				detachedTarget,
+			);
+
+			// Should not throw, but content should be in detached target
+			render(portal, container);
+			expect(detachedTarget.innerHTML).toBe("<div>Content</div>");
+		});
+
+		test("should handle portal with null children", () => {
+			const portal = createPortal(null, portalTarget);
+			render(portal, container);
+			expect(portalTarget.innerHTML).toBe("");
+		});
+
+		test("should handle portal with undefined children", () => {
+			const portal = createPortal(undefined, portalTarget);
+			render(portal, container);
+			expect(portalTarget.innerHTML).toBe("");
+		});
+
+		test("should handle portal target removal during render", () => {
+			const tempTarget = document.createElement("div");
+			document.body.appendChild(tempTarget);
+
+			const portal = createPortal(
+				createElement("div", null, "Content"),
+				tempTarget,
+			);
+
+			render(portal, container);
+			expect(tempTarget.innerHTML).toBe("<div>Content</div>");
+
+			// Remove target from DOM
+			document.body.removeChild(tempTarget);
+
+			// Re-render should handle gracefully
+			render(portal, container);
+			// Content should still be in the detached target
+			expect(tempTarget.innerHTML).toBe("<div>Content</div>");
+		});
+
+		test("should handle rapid portal creation and destruction", () => {
+			for (let i = 0; i < 100; i++) {
+				const portal = createPortal(
+					createElement("div", null, `Content ${i}`),
+					portalTarget,
+				);
+				render(portal, container);
+				expect(portalTarget.innerHTML).toBe(`<div>Content ${i}</div>`);
+			}
+
+			render(createElement("div", null, "Done"), container);
+			expect(portalTarget.innerHTML).toBe("");
+		});
+	});
+
+	describe("Performance", () => {
+		test("should efficiently update large portal content", () => {
+			function LargePortalList({ count }: { count: number }) {
+				const items = Array.from({ length: count }, (_, i) =>
+					createElement("div", { key: i }, `Item ${i}`),
+				);
+
+				return createPortal(createElement("div", null, ...items), portalTarget);
+			}
+
+			// Initial render with 1000 items
+			render(createElement(LargePortalList, { count: 1000 }), container);
+			expect(portalTarget.children).toHaveLength(1);
+			expect(portalTarget.firstElementChild?.children).toHaveLength(1000);
+
+			// Update to 1500 items
+			render(createElement(LargePortalList, { count: 1500 }), container);
+			expect(portalTarget.firstElementChild?.children).toHaveLength(1500);
+
+			// Update to 500 items
+			render(createElement(LargePortalList, { count: 500 }), container);
+			expect(portalTarget.firstElementChild?.children).toHaveLength(500);
+		});
+	});
+});

--- a/tests/MiniReact.render.test.ts
+++ b/tests/MiniReact.render.test.ts
@@ -1280,16 +1280,28 @@ describe("MiniReact.render", () => {
 				"Text before",
 				createElement(
 					"div",
-					{ key: "wrapper-1" },
-					createElement("span", { key: "nested-A" }, "Nested A"),
+					{ key: "wrapper-1", "data-wrapper": "1" },
+					createElement(
+						"span",
+						{ key: "nested-A", "data-nested": "A" },
+						"Nested A",
+					),
 					"Inner text",
-					createElement("span", { key: "nested-B" }, "Nested B"),
+					createElement(
+						"span",
+						{ key: "nested-B", "data-nested": "B" },
+						"Nested B",
+					),
 				),
 				42,
 				createElement(
 					"div",
-					{ key: "wrapper-2" },
-					createElement("p", { key: "nested-C" }, "Nested C"),
+					{ key: "wrapper-2", "data-wrapper": "2" },
+					createElement(
+						"p",
+						{ key: "nested-C", "data-nested": "C" },
+						"Nested C",
+					),
 				),
 				"Text after",
 			);
@@ -1297,8 +1309,12 @@ describe("MiniReact.render", () => {
 			render(element1, container);
 
 			const parent = container.querySelector("#nested-mixed") as HTMLElement;
-			const wrapper1 = parent.querySelector('[key="wrapper-1"]') as HTMLElement;
-			const nestedA = wrapper1.querySelector('[key="nested-A"]') as HTMLElement;
+			const wrapper1 = parent.querySelector(
+				'[data-wrapper="1"]',
+			) as HTMLElement;
+			const nestedA = wrapper1.querySelector(
+				'[data-nested="A"]',
+			) as HTMLElement;
 
 			// Rearrange and modify nested structure
 			const element2 = createElement(
@@ -1307,16 +1323,32 @@ describe("MiniReact.render", () => {
 				"Updated text before",
 				createElement(
 					"div",
-					{ key: "wrapper-2" }, // Reorder wrappers
-					createElement("p", { key: "nested-C" }, "Updated Nested C"),
-					createElement("span", { key: "nested-D" }, "New Nested D"),
+					{ key: "wrapper-2", "data-wrapper": "2" }, // Reorder wrappers
+					createElement(
+						"p",
+						{ key: "nested-C", "data-nested": "C" },
+						"Updated Nested C",
+					),
+					createElement(
+						"span",
+						{ key: "nested-D", "data-nested": "D" },
+						"New Nested D",
+					),
 				),
 				100, // Changed number
 				createElement(
 					"div",
-					{ key: "wrapper-1" },
-					createElement("span", { key: "nested-B" }, "Updated Nested B"),
-					createElement("span", { key: "nested-A" }, "Updated Nested A"),
+					{ key: "wrapper-1", "data-wrapper": "1" },
+					createElement(
+						"span",
+						{ key: "nested-B", "data-nested": "B" },
+						"Updated Nested B",
+					),
+					createElement(
+						"span",
+						{ key: "nested-A", "data-nested": "A" },
+						"Updated Nested A",
+					),
 					// Removed inner text, reordered nested elements
 				),
 			);
@@ -1329,20 +1361,20 @@ describe("MiniReact.render", () => {
 
 			// Verify nested structure and reuse
 			const updatedWrapper1 = updatedParent.querySelector(
-				'[key="wrapper-1"]',
+				'[data-wrapper="1"]',
 			) as HTMLElement;
 			const updatedNestedA = updatedWrapper1.querySelector(
-				'[key="nested-A"]',
+				'[data-nested="A"]',
 			) as HTMLElement;
 
 			expect(updatedNestedA).toBe(nestedA); // Should reuse nested element
 			expect(updatedNestedA.textContent).toBe("Updated Nested A");
 
 			// Verify order of wrapper elements changed
-			const wrapperKeys = Array.from(
-				updatedParent.querySelectorAll('[key^="wrapper-"]'),
-			).map((el) => el.getAttribute("key"));
-			expect(wrapperKeys).toEqual(["wrapper-2", "wrapper-1"]);
+			const wrapperDataValues = Array.from(
+				updatedParent.querySelectorAll("[data-wrapper]"),
+			).map((el) => el.getAttribute("data-wrapper"));
+			expect(wrapperDataValues).toEqual(["2", "1"]);
 		});
 
 		test("should handle functional components within keyed children", () => {


### PR DESCRIPTION
- Add createPortal API for rendering to different DOM containers
- Add Fragment support for multiple children without wrappers
- Implement portal event bubbling through React tree
- Add portal context propagation
- Add comprehensive test suites for both features

Fixes the functionality that was lost in the revert (PR #10)